### PR TITLE
Update notification handling to use PUT method for marking as read

### DIFF
--- a/client/src/components/notifications-dropdown.tsx
+++ b/client/src/components/notifications-dropdown.tsx
@@ -58,7 +58,7 @@ export default function NotificationsDropdown({
   const markAsReadMutation = useMutation({
     mutationFn: async (notificationId: number) => {
       const response = await fetch(`/api/notifications/${notificationId}/read`, {
-        method: 'POST',
+        method: 'PUT',
         credentials: 'include',
       });
       if (!response.ok) throw new Error('Failed to mark as read');
@@ -81,8 +81,8 @@ export default function NotificationsDropdown({
 
   const markAllAsReadMutation = useMutation({
     mutationFn: async () => {
-      const response = await fetch('/api/notifications/mark-all-read', {
-        method: 'POST',
+      const response = await fetch('/api/notifications/read-all', {
+        method: 'PUT',
         credentials: 'include',
       });
       if (!response.ok) throw new Error('Failed to mark all as read');

--- a/client/src/contexts/notification-context.tsx
+++ b/client/src/contexts/notification-context.tsx
@@ -105,8 +105,19 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
           duration: 4000,
         });
         
-        // Refresh notifications
-        queryClient.invalidateQueries({ queryKey: ['/api/notifications'] });
+        // Only refresh notifications if we're not in the middle of marking as read
+        // This prevents the "unread again" issue
+        const currentNotifications = queryClient.getQueryData(['/api/notifications']);
+        if (currentNotifications) {
+          // Add the new notification to existing data instead of refetching
+          queryClient.setQueryData(['/api/notifications'], (oldData: any) => {
+            if (!oldData) return oldData;
+            return [message.data, ...oldData];
+          });
+        } else {
+          // Only refetch if we don't have current data
+          queryClient.invalidateQueries({ queryKey: ['/api/notifications'] });
+        }
         
         // Update unread count
         setUnreadCount(prev => prev + 1);

--- a/client/src/pages/notifications.tsx
+++ b/client/src/pages/notifications.tsx
@@ -45,7 +45,7 @@ export default function NotificationsPage() {
   const markReadMutation = useMutation({
     mutationFn: async (id: number) => {
       const response = await fetch(`/api/notifications/${id}/read`, {
-        method: 'POST',
+        method: 'PUT',
         credentials: 'include',
       });
       if (!response.ok) {
@@ -60,8 +60,8 @@ export default function NotificationsPage() {
 
   const markAllReadMutation = useMutation({
     mutationFn: async () => {
-      const response = await fetch('/api/notifications/mark-all-read', {
-        method: 'POST',
+      const response = await fetch('/api/notifications/read-all', {
+        method: 'PUT',
         credentials: 'include',
       });
       if (!response.ok) {


### PR DESCRIPTION
- Changed API method from POST to PUT for marking individual and all notifications as read, aligning with RESTful practices.
- Enhanced notification context to conditionally refresh notifications, preventing the "unread again" issue by updating existing data instead of refetching when new notifications arrive.