### PR TITLE
Update nodemailer transport timeouts for improved connection reliability

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -107,9 +107,9 @@ const transporter = nodemailer.createTransport({
   tls: {
     rejectUnauthorized: false,
   },
-  connectionTimeout: 5000,
-  greetingTimeout: 5000,
-  socketTimeout: 10000,
+  connectionTimeout: 30000,  // 30 seconds
+  greetingTimeout: 30000,    // 30 seconds  
+  socketTimeout: 60000,      // 60 seconds
 });
 
 // Generate 6-digit OTP


### PR DESCRIPTION
- Increased connectionTimeout to 30 seconds, greetingTimeout to 30 seconds, and socketTimeout to 60 seconds to enhance the reliability of email transport connections.