### PR TITLE
Refactor nodemailer transport creation in SMTP testing

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -276,7 +276,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     
     for (const config of testConfigs) {
       try {
-        const testTransporter = nodemailer.createTransporter({
+        const testTransporter = nodemailer.createTransport({
           host: config.host,
           port: config.port,
           secure: config.secure,


### PR DESCRIPTION
- Updated the nodemailer transport creation method from `createTransporter` to `createTransport` for consistency with the latest API.
- This change aligns with recent updates in the nodemailer library, ensuring compatibility and improved functionality in SMTP configuration testing.